### PR TITLE
add a plugins value in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   entry: {
@@ -9,6 +10,12 @@ module.exports = {
     path: __dirname,
     filename: "[name].bundle.js"
   },
+  plugins: [
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery"
+    })
+  ],
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },


### PR DESCRIPTION
* this defines jQuery plugins to resolve an error with Webapck
not being able to resolve jsdom, location, navigator, and xmlhttprequest modules in the jQuery node modules